### PR TITLE
Update isArray require to be case-sensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var random = require('random-seed');
 var assign = require('lodash/object/assign');
-var isArray = require('lodash/lang/isarray');
+var isArray = require('lodash/lang/isArray');
 
 var defaults = {
   seed: null,


### PR DESCRIPTION
pf-perlin is fantastic, thank you!

This just fixes a little warning I get when using pf-perlin with webpack:

WARNING in ../~/pf-perlin/~/lodash/lang/isArray.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.
